### PR TITLE
Improvements to 'install.sh'

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ if ! which wget 2> /dev/null; then
     display_error "'wget' has not been found in the system. Please install the package first to proceed."
 
 elif ! which unzip 2> /dev/null; then
-    display_error "'wget' has not been found in the system. Please install the package first to proceed."
+    display_error "'unzip' has not been found in the system. Please install the package first to proceed."
 fi
 
 # Download the application archive and extract it to the installation directory

--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,36 @@
 #!/bin/sh
 
+ARG="${1}"
+
 VERSION="v1.4"
-INSTALL_DIR="$HOME"
-BIN_DIR="$INSTALL_DIR/ssl-handshake-debugger/bin"
+
+# If calling './install.sh local', deploy it in the local working directory instead of $HOME
+
+if [[ -n ${ARG} ]] && [[ "${ARG,,}" == "local" ]]; then
+    INSTALL_DIR="$PWD"
+    BIN_DIR="$INSTALL_DIR/bin"
+
+else
+    INSTALL_DIR="$HOME"
+    BIN_DIR="$INSTALL_DIR/ssl-handshake-debugger/bin"
+fi
+
 DOWNLOAD_URL="https://github.com/gabrielpadilh4/ssl-handshake-debugger/releases/download/$VERSION/ssl-handshake-debugger.zip"
 ZIP_DOWNLOAD_FILE_NAME="ssl-handshake-debugger.zip"
-
 
 function display_error() {
     echo "Error: $1"
     exit 1
 }
+
+# Verify whether 'wget' and 'unzip' exists
+
+if ! which wget 2> /dev/null; then
+    display_error "'wget' has not been found in the system. Please install the package first to proceed."
+
+elif ! which unzip 2> /dev/null; then
+    display_error "'wget' has not been found in the system. Please install the package first to proceed."
+fi
 
 # Download the application archive and extract it to the installation directory
 echo "Downloading and extracting the application..."
@@ -19,7 +39,17 @@ wget -q -O /tmp/$ZIP_DOWNLOAD_FILE_NAME "$DOWNLOAD_URL" && unzip -o /tmp/$ZIP_DO
 # Add the application's bin directory to the PATH
 echo "Updating PATH to include the application..."
 
-echo "export PATH=\"$BIN_DIR:\$PATH\"" >> "$HOME/.bashrc"
+# Verify whether the $PATH already exists to avoid duplicate installations
+
+VALIDATE_PATH=$(< $HOME/.bashrc grep "PATH=\"$BIN_DIR:\$PATH\"")
+
+if [[ -n ${VALIDATE_PATH} ]]; then
+    echo "PATH=\"$BIN_DIR:\$PATH\" already exists in: $HOME/.bashrc. Not adding to avoid duplicates."
+
+else
+    echo "export PATH=\"$BIN_DIR:\$PATH\"" >> "$HOME/.bashrc"
+fi
+
 source "$HOME/.bashrc"
 
 echo "Installation successful! Use 'ssl-handshake-debugger -h' command to run the application."


### PR DESCRIPTION
Closes #24 and performs some other improvements:

- If the script is called using "local", it will be deployed in the local directory instead of '/home'.

- Confirms that both 'wget' and 'unzip' exists.

- Avoid duplicate entries in the $PATH (#24).